### PR TITLE
Corrected example URL in ReadMe file to point to ClearBlade instead o…

### DIFF
--- a/examples/iot_core_mqtt_client/README.md
+++ b/examples/iot_core_mqtt_client/README.md
@@ -23,4 +23,4 @@ cd bin \
 ./iot_core_mqtt_client -p <i><b>PROJECT_ID</b></i> -d projects/<i><b>PROJECT_ID</b></i>/locations/<i><b>REGION</b></i>/registries/<i><b>REGISTRY_ID</b></i>/devices/<i><b>DEVICE_ID</b></i> -t /devices/<i><b>DEVICE_ID</b></i>/state
 </pre>
 
-You may optionally send message, mqtt url and port with flags -u and -n respectively. example: -m something -u mqtt.2030.ltsapis.goog -n 8883
+You may optionally send message, mqtt url and port with flags -u and -n respectively. example: -m something -u us-central1-mqtt.clearblade.com -n 8883


### PR DESCRIPTION
Corrected example URL in ReadMe file to point to ClearBlade instead of google URL