### PR TITLE
Don't needlessly copy client ID in iotc_connect

### DIFF
--- a/src/libiotc/iotc.c
+++ b/src/libiotc/iotc.c
@@ -390,25 +390,20 @@ uint16_t port_val_local;
 #define IOTC_MQTT_HOST_ACCESSOR_US_CENTRAL ((iotc_static_host_desc_t)IOTC_MQTT_HOST_US_CENTRAL)
 #define IOTC_MQTT_HOST_ACCESSOR_EUROPE_WEST1 ((iotc_static_host_desc_t)IOTC_MQTT_HOST_EUROPE_WEST1)
 #define IOTC_MQTT_HOST_ACCESSOR_ASIA_EAST1 ((iotc_static_host_desc_t)IOTC_MQTT_HOST_ASIA_EAST1)
-char local_client_id[2048];
-memset(local_client_id,0,sizeof(char));
-if(NULL != client_id){    
-    memcpy(local_client_id, client_id, strlen(client_id));
-}
 
 //har *uscentral1 = "us-central1";
 char *europewest1 = "europe-west1";
 char *asiaeast1 = "asia-east1";
 
-if (strcasestr(local_client_id, europewest1) != NULL) {
+if (client_id && strcasestr(client_id, europewest1) != NULL) {
     host_name_local = IOTC_MQTT_HOST_ACCESSOR_EUROPE_WEST1.name;
     port_val_local = IOTC_MQTT_HOST_ACCESSOR_EUROPE_WEST1.port;
 }
-else if (strcasestr(local_client_id, asiaeast1) != NULL) {
+else if (client_id && strcasestr(client_id, asiaeast1) != NULL) {
     host_name_local = IOTC_MQTT_HOST_ACCESSOR_ASIA_EAST1.name;
     port_val_local = IOTC_MQTT_HOST_ACCESSOR_ASIA_EAST1.port;
 }
-else /*(strcasestr(local_client_id, uscentral1) != NULL)*/ {
+else /*(client_id && strcasestr(client_id, uscentral1) != NULL)*/ {
     /* use this as default value */
     host_name_local = IOTC_MQTT_HOST_ACCESSOR_US_CENTRAL.name;
     port_val_local = IOTC_MQTT_HOST_ACCESSOR_US_CENTRAL.port;


### PR DESCRIPTION
We were bumping into stack overflows when calling `iotc_connect` in a FreeRTOS task with pretty limited stack space. The (relatively) high stack usage appears to be due to `local_client_id`, a buffer of 2048 bytes in `iotc_connect`.

`iotc_connect` was:
* copying `client_id` into a local (stack) variable `local_client_id`
* using `local_client_id` to find substrings with `strcasestr`
* discarding `local_client_id`

We can just use `client_id` directly in these `strcasestr` calls (provided we check for NULL first).

----------

I verified this change with `make tests` but unfortunately the tests are broken on ClearBlade's master branch -- on my system, I get:

```console
foo@bar: iot-device-sdk-embedded-c $ make tests
(cd path/to/iot-device-sdk-embedded-c/bin/linux/tests/ && LD_LIBRARY_PATH=path/to/iot-device-sdk-embedded-c/bin/linux/:$LD_LIBRARY_PATH exec path/to/iot-device-sdk-embedded-c/bin/linux/tests/iotc_utests -l0)
[.RUN      ] utest_connect - test_INVALID_connect_context
 connecting to host us-central1-mqtt.clearblade.com with port 443 
[       OK ] utest_connect - test_INVALID_connect_context (0 ms)
[.RUN      ] utest_connect - test_VALID_connect_context
 connecting to host us-central1-mqtt.clearblade.com with port 443 
[       OK ] utest_connect - test_VALID_connect_context (0 ms)

// ... more tests run here ...

[.RUN      ] utest_mqtt_logic_layer_subscribe - utest__match_topics__batch_tests
[       OK ] utest_mqtt_logic_layer_subscribe - utest__match_topics__batch_tests (0 ms)
[.RUN      ] utest_mqtt_logic_layer_subscribe - utest__do_mqtt_subscribe__valid_data__subscription_handler_registered_with_success

  FAIL path/to/iot-device-sdk-embedded-c/src/tests/utests/iotc_utest_mqtt_logic_layer_subscribe.c:235: assert(do_mqtt_subscribe(&layer->layer_connection, task, IOTC_STATE_OK, msg) == IOTC_STATE_OK): 7 vs 0

  FAIL path/to/iot-device-sdk-embedded-c/src/tests/utests/iotc_utest_mqtt_logic_layer_subscribe.c:238: assert(logic_layer_data.handlers_for_topics->elem_no == 1): 0 vs 1

  FAIL path/to/iot-device-sdk-embedded-c/src/tests/utests/iotc_utest_mqtt_logic_layer_subscribe.c:239: assert(logic_layer_data.handlers_for_topics->array[0].selector_t.ptr_value == data_u): (nil) vs 0x557ef66d1f48
Segmentation fault (core dumped)
make: *** [Makefile:116: utests] Error 139
```

For what it's worth, the unit tests _do_ succeed up to the same point after this change (including successfully running many of the `utest_connect` tests, which would exercise the code paths affected by this change).